### PR TITLE
Upgrade PostgreSQL images to version 17 in Docker configurations

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -31,7 +31,7 @@ services:
   #   volumes:
   #     - ./docker/mariadb/datas:/var/lib/mysql
   pgsql:
-    image: postgres:16
+    image: postgres:17
     ports:
       - '${FORWARD_DB_PORT:-5432}:5432'
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -37,7 +37,7 @@ services:
   #   volumes:
   #     - ./docker/mariadb/datas:/var/lib/mysql
   pgsql:
-    image: postgres:14
+    image: postgres:17
     restart: always
     ports:
       - '${FORWARD_DB_PORT:-5432}:5432'


### PR DESCRIPTION
Update Docker configurations to use PostgreSQL version 17 for improved performance and features.