### PR TITLE
Upgrade Node.js to version 25 in documentation and Docker Compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - HTTP server Nginx 1.25
 - PHP 8.4
-- Node 20
+- Node 25
 - PostgreSQL 16 or MariaDB 11
 
 ## Install Laravel

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
     depends_on:
       - pgsql
   node:
-    image: node:20
+    image: node:25
     ports:
       - 5173:5173
     volumes:


### PR DESCRIPTION
Update the Node.js version in the README and Docker Compose configuration to reflect the upgrade to version 25.